### PR TITLE
latex-beamer: Allow bibliography to span multiple Pages

### DIFF
--- a/lmu-example.tex
+++ b/lmu-example.tex
@@ -304,7 +304,7 @@
 \end{frame}
 
 \subsection{References}
-\begin{frame}
+\begin{frame}[allowframebreaks]
 	\frametitle{References}
 	\nocite{*}
 	\printbibliography[heading=none]


### PR DESCRIPTION
Right now the "References" slide overflows after too many entrys. This change makes latex span the references over multiple slides. 