### PR TITLE
layout: Do not include reference slides into numbering

### DIFF
--- a/lmu-example.tex
+++ b/lmu-example.tex
@@ -12,7 +12,7 @@
 
 % setup sectionpage
 \AtBeginSection{
-    \begin{frame}[allowframebreaks]{Outline}
+    \begin{frame}[allowframebreaks,noframenumbering]{Outline}
         \tableofcontents[currentsection]
     \end{frame}
 }


### PR DESCRIPTION
Hi,

i would suggest to leave the reference slides out of the overall slide numbering since they usually not shown and only included for the sake of completeness.

Regards,
Robin