### PR TITLE
Header: Align logo box on title slide with content

### DIFF
--- a/style/beamerinnerthemelmu.sty
+++ b/style/beamerinnerthemelmu.sty
@@ -24,21 +24,14 @@
 		\ifnum\thepage>1\relax%
             % rectangle for title
 			\draw[color=lmu@hyperlink] (31.2mm,\the\paperheight-15mm)
-            rectangle (\the\paperwidth-50mm,\the\paperheight-2mm);
+			rectangle (\the\paperwidth-50mm,\the\paperheight-2mm);
+		\fi%
 			\node[anchor=south east,inner sep=0,draw,color=lmu@hyperlink] at
 			(\the\paperwidth-2mm,\the\paperheight-15mm) {
 				%\hspace{10mm}%
                 \includegraphics{mnmLogoNeu.pdf}%
 				\hspace{2mm}%
                 \includegraphics[trim={0 12mm 24mm 12mm}, clip, height=13mm]{siegel.pdf}};
-		\else%
-			\node[anchor=south east,inner sep=0,draw,color=lmu@hyperlink] at
-			(\the\paperwidth-2mm,\the\paperheight-15mm) {
-				%\hspace{10mm}%
-                \includegraphics{mnmLogoNeu.pdf}%
-            };
-			\node[anchor=south east,inner sep=0] at (\the\paperwidth+12mm,-5mm) { \includegraphics[height=55mm]{siegel.pdf} };
-		\fi
 	\end{tikzpicture}
 }
 


### PR DESCRIPTION
Currently the MNM-Logo on the title slide is missing the LMU signet. This results in a different box width on the title slide in contrast to the content slides.

I would suggest to add the LMU signet in the title slide as well. This results in a more uniform look & feel and do not result in a visual glitch when switching to the second slide.
